### PR TITLE
added configuration to get rid of gem backtrace.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,4 +8,6 @@ RSpec.configure do |config|
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
   end
+
+  config.backtrace_exclusion_patterns << %r{/gems/}
 end


### PR DESCRIPTION
I added a configuration at the bottom of the spec helper so that it cleans up the backtraces, and it makes it easier to see the errors.
